### PR TITLE
Merchant sees unfulfilled orders#35

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -19,6 +19,8 @@ class MerchantsController < ApplicationController
   def show
     @merchant = current_user
     @placeholder_image_items = @merchant.my_placeholder_image_items
+    @num_unfulfilled_orders = @merchant.my_number_unfulfilled_orders
+    @revenue_unfulfilled_orders = @merchant.my_revenue_unfulfilled_orders
     @orders = @merchant.my_pending_orders
     @top_5_items = @merchant.top_items_by_quantity(5)
     @qsp = @merchant.quantity_sold_percentage

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,4 +116,8 @@ class User < ApplicationRecord
   def my_placeholder_image_items
     items.where(image: 'https://picsum.photos/200/300/?image=524')
   end
+  
+  def my_number_unfulfilled_orders
+    my_pending_orders.count
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,4 +120,9 @@ class User < ApplicationRecord
   def my_number_unfulfilled_orders
     my_pending_orders.count
   end
+  
+  def my_revenue_unfulfilled_orders
+    my_pending_orders.joins(:order_items)
+    .sum("order_items.quantity * order_items.price")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
   def my_pending_orders
     Order.joins(order_items: :item)
       .where("items.merchant_id=? AND orders.status=? AND order_items.fulfilled=?", self.id, 0, false)
+      .distinct
   end
 
   def inventory_check(item_id)

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -20,6 +20,9 @@
     <% end %>
     </ul>
     <h5>Unfulfilled Orders</h5>
+    <ul>
+      <li>You have <%= @num_unfulfilled_orders %> unfulfilled orders, worth <%= number_to_currency(@revenue_unfulfilled_orders) %>.</li>
+    </ul>
   </div>
   <p><%= link_to 'My Items', dashboard_items_path %></p>
   <p><%= link_to 'Create New Coupon', new_coupon_path %></p>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -21,7 +21,7 @@
     </ul>
     <h5>Unfulfilled Orders</h5>
     <ul>
-      <li>You have <%= @num_unfulfilled_orders %> unfulfilled orders, worth <%= number_to_currency(@revenue_unfulfilled_orders) %>.</li>
+      <li>You have <%= pluralize(@num_unfulfilled_orders, 'unfulfilled order') %>, worth <%= number_to_currency(@revenue_unfulfilled_orders) %>.</li>
     </ul>
   </div>
   <p><%= link_to 'My Items', dashboard_items_path %></p>

--- a/spec/features/merchant/dashboard_spec.rb
+++ b/spec/features/merchant/dashboard_spec.rb
@@ -275,62 +275,105 @@ RSpec.describe 'Merchant Dashboard page' do
     end
   end
   
-  it 'should show me a to do list' do
-    merchant = create(:merchant)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+  context 'To Do List' do
+    it 'should show me a to do list' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      
+      visit dashboard_path
+      
+      expect(page).to have_content("To Do List")
+      within "#to-do" do
+        expect(page).to have_content("Items Using Placeholder Images")
+        expect(page).to have_content("Unfulfilled Orders")
+      end
+    end
     
-    visit dashboard_path
+    it 'should show me all items that are using placeholder images' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      
+      item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+      item_2 = create(:item, user: merchant)
+      item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+      
+      visit dashboard_path
+      
+      within "#to-do" do
+        expect(page).to have_link(item_1.name)
+        expect(page).to have_link(item_3.name)
+        expect(page).to_not have_content(item_2.name)
+      end
+    end
     
-    expect(page).to have_content("To Do List")
-    within "#to-do" do
-      expect(page).to have_content("Items Using Placeholder Images")
-      expect(page).to have_content("Unfulfilled Orders")
+    it 'should let me update items with placeholder images' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      
+      item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+      item_2 = create(:item, user: merchant)
+      item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+      
+      visit dashboard_path
+      
+      within "#to-do" do
+        click_link(item_1.name)
+      end
+      expect(current_path).to eq(edit_dashboard_item_path(item_1))
+      fill_in :item_image, with: 'https://picsum.photos/200/300/?image=5'
+      click_button 'Update Item'
+      
+      expect(current_path).to eq(dashboard_items_path)
+      click_link('Dashboard')
+      
+      within "#to-do" do
+        expect(page).to have_link(item_3.name)
+        expect(page).to_not have_link(item_1.name)
+        expect(page).to_not have_link(item_2.name)
+      end
+    end
+    
+    it 'should show me information about my unfulfilled orders' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      item_3 = create(:item, user: merchant)
+      
+      order_1 = create(:order)
+      order_2 = create(:order)
+      order_3 = create(:order)
+      order_4 = create(:completed_order)
+      order_5 = create(:cancelled_order)
+      
+      # Standard unfulfilled order 
+      oi_1 = create(:order_item, item: item_1, order: order_1)
+      
+      # Order with one item fulfilled and one unfulfilled
+      oi_2 = create(:order_item, item: item_2, order: order_2)
+      create(:fulfilled_order_item, item: item_1, order: order_2)
+      
+      # Order where merchant's only item is fulfilled (but order is not completed)
+      create(:fulfilled_order_item, item: item_3, order: order_3)
+      
+      # Completed order with fulfilled order_item
+      create(:fulfilled_order_item, item: item_3, order: order_4)
+      
+      # Cancelled order with unfulfilled order_item
+      create(:order_item, item: item_3, order: order_5)
+      
+      visit dashboard_path
+      
+      unfulfilled_orders = 2
+      unfulfilled_orders_revenue = (oi_1.price * oi_1.quantity) + (oi_2.price * oi_2.quantity)
+      
+      within "#to-do" do
+        expect(page).to have_content("You have #{unfulfilled_orders} unfulfilled orders, worth #{number_to_currency(unfulfilled_orders_revenue)}.")
+      end
     end
   end
   
-  it 'should show me all items that are using placeholder images' do
-    merchant = create(:merchant)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-    
-    item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-    item_2 = create(:item, user: merchant)
-    item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-    
-    visit dashboard_path
-    
-    within "#to-do" do
-      expect(page).to have_link(item_1.name)
-      expect(page).to have_link(item_3.name)
-      expect(page).to_not have_content(item_2.name)
-    end
-  end
-  
-  it 'should let me update items with placeholder images' do
-    merchant = create(:merchant)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-    
-    item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-    item_2 = create(:item, user: merchant)
-    item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-    
-    visit dashboard_path
-    
-    within "#to-do" do
-      click_link(item_1.name)
-    end
-    expect(current_path).to eq(edit_dashboard_item_path(item_1))
-    fill_in :item_image, with: 'https://picsum.photos/200/300/?image=5'
-    click_button 'Update Item'
-    
-    expect(current_path).to eq(dashboard_items_path)
-    click_link('Dashboard')
-    
-    within "#to-do" do
-      expect(page).to have_link(item_3.name)
-      expect(page).to_not have_link(item_1.name)
-      expect(page).to_not have_link(item_2.name)
-    end
-  end
 
   context 'as an admin' do
   end

--- a/spec/features/merchant/dashboard_spec.rb
+++ b/spec/features/merchant/dashboard_spec.rb
@@ -350,6 +350,12 @@ RSpec.describe 'Merchant Dashboard page' do
       # Standard unfulfilled order 
       oi_1 = create(:order_item, item: item_1, order: order_1)
       
+      visit dashboard_path
+      
+      within "#to-do" do
+        expect(page).to have_content("You have 1 unfulfilled order, worth #{number_to_currency(oi_1.price * oi_1.quantity)}")
+      end
+      
       # Order with one item fulfilled and one unfulfilled
       oi_2 = create(:order_item, item: item_2, order: order_2)
       create(:fulfilled_order_item, item: item_1, order: order_2)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,35 +113,42 @@ RSpec.describe User, type: :model do
       expect(merchant.my_placeholder_image_items).to eq([item_1, item_3])
     end
     
-    it '.my_number_unfulfilled_orders' do
-      merchant = create(:merchant)
-      item_1 = create(:item, user: merchant)
-      item_2 = create(:item, user: merchant)
-      item_3 = create(:item, user: merchant)
-      
-      order_1 = create(:order)
-      order_2 = create(:order)
-      order_3 = create(:order)
-      order_4 = create(:completed_order)
-      order_5 = create(:cancelled_order)
-      
-      # Standard unfulfilled order 
-      oi_1 = create(:order_item, item: item_1, order: order_1)
-      
-      # Order with one item fulfilled and one unfulfilled
-      oi_2 = create(:order_item, item: item_2, order: order_2)
-      create(:fulfilled_order_item, item: item_1, order: order_2)
-      
-      # Order where merchant's only item is fulfilled (but order is not completed)
-      create(:fulfilled_order_item, item: item_3, order: order_3)
-      
-      # Completed order with fulfilled order_item
-      create(:fulfilled_order_item, item: item_3, order: order_4)
-      
-      # Cancelled order with unfulfilled order_item
-      create(:order_item, item: item_3, order: order_5)
-      
-      expect(merchant.my_number_unfulfilled_orders).to eq(2)
+    describe 'unfulfilled orders details' do
+      before(:each) do
+        @merchant = create(:merchant)
+        item_1 = create(:item, user: @merchant)
+        item_2 = create(:item, user: @merchant)
+        item_3 = create(:item, user: @merchant)
+        
+        order_1 = create(:order)
+        order_2 = create(:order)
+        order_3 = create(:order)
+        order_4 = create(:completed_order)
+        order_5 = create(:cancelled_order)
+        
+        # Standard unfulfilled order 
+        @oi_1 = create(:order_item, item: item_1, order: order_1)
+        
+        # Order with one item fulfilled and one unfulfilled
+        @oi_2 = create(:order_item, item: item_2, order: order_2)
+        create(:fulfilled_order_item, item: item_1, order: order_2)
+        
+        # Order where merchant's only item is fulfilled (but order is not completed)
+        create(:fulfilled_order_item, item: item_3, order: order_3)
+        
+        # Completed order with fulfilled order_item
+        create(:fulfilled_order_item, item: item_3, order: order_4)
+        
+        # Cancelled order with unfulfilled order_item
+        create(:order_item, item: item_3, order: order_5)
+      end
+  
+      it '.my_number_unfulfilled_orders' do
+        expect(@merchant.my_number_unfulfilled_orders).to eq(2)
+      end
+      it '.my_revenue_unfulfilled_orders' do
+        expect(@merchant.my_revenue_unfulfilled_orders).to eq((@oi_1.price * @oi_1.quantity) + (@oi_2.price * @oi_2.quantity))
+      end
     end
 
     describe 'merchant stats methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,6 +112,37 @@ RSpec.describe User, type: :model do
       
       expect(merchant.my_placeholder_image_items).to eq([item_1, item_3])
     end
+    
+    it '.my_number_unfulfilled_orders' do
+      merchant = create(:merchant)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      item_3 = create(:item, user: merchant)
+      
+      order_1 = create(:order)
+      order_2 = create(:order)
+      order_3 = create(:order)
+      order_4 = create(:completed_order)
+      order_5 = create(:cancelled_order)
+      
+      # Standard unfulfilled order 
+      oi_1 = create(:order_item, item: item_1, order: order_1)
+      
+      # Order with one item fulfilled and one unfulfilled
+      oi_2 = create(:order_item, item: item_2, order: order_2)
+      create(:fulfilled_order_item, item: item_1, order: order_2)
+      
+      # Order where merchant's only item is fulfilled (but order is not completed)
+      create(:fulfilled_order_item, item: item_3, order: order_3)
+      
+      # Completed order with fulfilled order_item
+      create(:fulfilled_order_item, item: item_3, order: order_4)
+      
+      # Cancelled order with unfulfilled order_item
+      create(:order_item, item: item_3, order: order_5)
+      
+      expect(merchant.my_number_unfulfilled_orders).to eq(2)
+    end
 
     describe 'merchant stats methods' do
       before :each do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,10 +84,12 @@ RSpec.describe User, type: :model do
       merchants = create_list(:merchant, 2)
       item_1 = create(:item, user: merchants[0])
       item_2 = create(:item, user: merchants[1])
+      item_3 = create(:item, user: merchants[0])
       orders = create_list(:order, 3)
       create(:order_item, order: orders[0], item: item_1, price: 1, quantity: 1)
       create(:order_item, order: orders[1], item: item_2, price: 1, quantity: 1)
       create(:order_item, order: orders[2], item: item_1, price: 1, quantity: 1)
+      create(:order_item, order: orders[2], item: item_3)
 
       expect(merchants[0].my_pending_orders).to eq([orders[0], orders[2]])
       expect(merchants[1].my_pending_orders).to eq([orders[1]])


### PR DESCRIPTION
- Adds unfulfilled order information to the merchant dashboard view and controller
- Adds methods for my_number_unfulfilled_orders and my_revenue_unfulfilled_orders
- Updates my_pending_order method to return distinct orders
- All tests passing
Closes #35 