### PR TITLE
Coupon info to items#30

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -133,3 +133,11 @@
   float: right;
   width: 33%;
 }
+
+#coupon {
+  display: inline-block;
+  border: 1px solid black;
+  padding: 10px 50px 0 50px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -7,6 +7,17 @@
   <%= @order.user.city %>, <%= @order.user.state %> <%= @order.user.zip %>
 <% end %>
 
+<% if @order.coupon %>
+  <div id="coupon">    
+    <p>Coupon applied: <%= @order.coupon.code %></p>
+    <% if @order.coupon.coupon_type == 'percentage' %>
+      <p>Discount: <%= @order.coupon.amount %>% on your items</p>
+    <% else %>
+      <p>Discount: <%= number_to_currency(@order.coupon.amount) %>, cart minimum <%= number_to_currency(@order.coupon.cart_minimum) %></p>
+    <% end %>
+  </div>
+<% end %>
+
 <%= tag.div id: 'order-details' do %>
   <p>Status: <%= @order.status %></p>
 

--- a/app/views/merchants/_order_card.html.erb
+++ b/app/views/merchants/_order_card.html.erb
@@ -2,3 +2,13 @@
 <p>Created: <%= order.created_at %></p>
 <p>Items in Order: <%= order.my_item_count(@merchant.id) %></p>
 <p>Value of Order: <%= number_to_currency(order.my_revenue_value(@merchant.id)) %></p>
+<% if order.coupon %>
+  <div id="coupon">    
+    <p>Coupon applied: <%= order.coupon.code %></p>
+    <% if order.coupon.coupon_type == 'percentage' %>
+      <p>Discount: <%= order.coupon.amount %>% on your items</p>
+    <% else %>
+      <p>Discount: <%= number_to_currency(order.coupon.amount) %>, cart minimum <%= number_to_currency(order.coupon.cart_minimum) %></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -25,6 +25,7 @@
     </ul>
   </div>
   <p><%= link_to 'My Items', dashboard_items_path %></p>
+  <p><%= link_to 'My Coupons', coupons_path %></p>
   <p><%= link_to 'Create New Coupon', new_coupon_path %></p>
 <% end %>
 

--- a/app/views/profile/orders/_order_item.html.erb
+++ b/app/views/profile/orders/_order_item.html.erb
@@ -8,12 +8,8 @@
     <p>Price: <%= number_to_currency(oitem.price) %></p>
     <p>Quantity: <%= oitem.quantity %></p>
     <p>Subtotal: <%= number_to_currency(oitem.subtotal) %></p>
-    <% if oitem.coupon && oitem.coupon.cart_minimum < order.my_revenue_value(oitem.item.user) %>
-      <% if oitem.coupon.coupon_type == 'percentage' %>
-        <p>Discount: <%= oitem.coupon.amount %>%</p>
-      <% else %>
-        <p>Discount: <%= number_to_currency(oitem.coupon.amount) %></p>
-      <% end %>
+    <% if oitem.coupon && oitem.coupon.coupon_type == 'percentage' %>
+      <p>Discount: <%= oitem.coupon.amount %>%</p>
     <% end %>
     <p>Fulfilled: <%= oitem.fulfilled ? 'Yes' : 'No' %></p>
   </div>

--- a/app/views/profile/orders/_order_item.html.erb
+++ b/app/views/profile/orders/_order_item.html.erb
@@ -8,6 +8,13 @@
     <p>Price: <%= number_to_currency(oitem.price) %></p>
     <p>Quantity: <%= oitem.quantity %></p>
     <p>Subtotal: <%= number_to_currency(oitem.subtotal) %></p>
+    <% if oitem.coupon && oitem.coupon.cart_minimum < order.my_revenue_value(oitem.item.user) %>
+      <% if oitem.coupon.coupon_type == 'percentage' %>
+        <p>Discount: <%= oitem.coupon.amount %>%</p>
+      <% else %>
+        <p>Discount: <%= number_to_currency(oitem.coupon.amount) %></p>
+      <% end %>
+    <% end %>
     <p>Fulfilled: <%= oitem.fulfilled ? 'Yes' : 'No' %></p>
   </div>
 </div>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -4,13 +4,15 @@
   <p>Last Update: <%= @order.last_update %></p>
   <p>Status: <%= @order.status %></p>
   <% if @order.coupon %>
-    <p>Coupon applied: <%= @order.coupon.code %> for merchant: <%= @order.coupon.user.name %></p>
-    <% if @order.coupon.coupon_type == 'percentage' %>
-      <p>Discount: <%= @order.coupon.amount %>% for items from merchant <%= @order.coupon.user.name %></p>
-    <% else %>
-      <p>Discount: <%= number_to_currency(@order.coupon.amount) %> from merchant <%= @order.coupon.user.name %></p>
-      <p><%= number_to_currency(@order.coupon.cart_minimum) %> cart minimum amount</p>
-    <% end %>
+    <div id="coupon">    
+      <p>Coupon applied: <%= @order.coupon.code %> for merchant: <%= @order.coupon.user.name %></p>
+      <% if @order.coupon.coupon_type == 'percentage' %>
+        <p>Discount: <%= @order.coupon.amount %>% for items from merchant <%= @order.coupon.user.name %></p>
+      <% else %>
+        <p>Discount: <%= number_to_currency(@order.coupon.amount) %> from merchant <%= @order.coupon.user.name %></p>
+        <p><%= number_to_currency(@order.coupon.cart_minimum) %> cart minimum amount</p>
+      <% end %>
+    </div>
   <% end %>
   <p>Item Count: <%= @order.total_item_count %></p>
   <p>Total Cost: <%= number_to_currency(@order.total_cost) %></p>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -21,7 +21,7 @@
 
   <% @order.order_items.each do |oitem| %>
     <%= tag.div id: "oitem-#{oitem.id}" do %>
-      <%= render partial: "/profile/orders/order_item", locals: {oitem: oitem, img_width: 150} %>
+      <%= render partial: "/profile/orders/order_item", locals: {oitem: oitem, order: @order, img_width: 150} %>
     <% end %>
   <% end %>
 

--- a/spec/features/merchant/crud_coupon_spec.rb
+++ b/spec/features/merchant/crud_coupon_spec.rb
@@ -11,9 +11,14 @@ describe 'As a merchant on the site' do
     click_button 'Log in'
   end
   describe 'on my dashboard' do
-    it 'I see a link to create a new coupon' do
+    it 'I see links to the coupon index and to create a new coupon' do
       visit dashboard_path
       
+      expect(page).to have_link("My Coupons")
+      click_link("My Coupons")
+      expect(current_path).to eq(coupons_path)
+      
+      visit dashboard_path
       expect(page).to have_link("Create New Coupon")
       click_link("Create New Coupon")
       expect(current_path).to eq(new_coupon_path)

--- a/spec/features/merchant/dashboard_spec.rb
+++ b/spec/features/merchant/dashboard_spec.rb
@@ -373,33 +373,44 @@ RSpec.describe 'Merchant Dashboard page' do
   end
   
   describe 'when I have pending orders with coupons applied' do
-    it 'should show me the coupon info' do
+    before(:each) do
       merchant = create(:merchant)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
       
       item_1 = create(:item, user: merchant)
       item_2 = create(:item, user: merchant)
       
-      coupon = create(:percent_coupon)
-      coupon_2 = create(:dollar_coupon, cart_minimum: 1)
+      @coupon = create(:percent_coupon)
+      @coupon_2 = create(:dollar_coupon, cart_minimum: 1)
       
-      order_1 = create(:order)
-      order_2 = create(:order)
+      @order_1 = create(:order)
+      @order_2 = create(:order)
       
-      oi_1 = create(:coupon_order_item, item: item_1, order: order_1, coupon: coupon)
-      oi_2 = create(:coupon_order_item, item: item_2, order: order_2, coupon: coupon_2)
-      
+      oi_1 = create(:coupon_order_item, item: item_1, order: @order_1, coupon: @coupon)
+      oi_2 = create(:coupon_order_item, item: item_2, order: @order_2, coupon: @coupon_2)
+    end
+    it 'should show me the coupon info' do      
       visit dashboard_path
       
-      within "#order-#{order_1.id}" do
-        expect(page).to have_content("Coupon applied: #{coupon.code}")
-        expect(page).to have_content("Discount: #{coupon.amount}% on your items")
+      within "#order-#{@order_1.id}" do
+        expect(page).to have_content("Coupon applied: #{@coupon.code}")
+        expect(page).to have_content("Discount: #{@coupon.amount}% on your items")
       end
       
-      within "#order-#{order_2.id}" do
-        expect(page).to have_content("Coupon applied: #{coupon_2.code}")
-        expect(page).to have_content("Discount: #{number_to_currency(coupon_2.amount)}, cart minimum #{number_to_currency(coupon_2.cart_minimum)}")
+      within "#order-#{@order_2.id}" do
+        expect(page).to have_content("Coupon applied: #{@coupon_2.code}")
+        expect(page).to have_content("Discount: #{number_to_currency(@coupon_2.amount)}, cart minimum #{number_to_currency(@coupon_2.cart_minimum)}")
       end
+    end
+    
+    it 'should show me the coupon info on the order show page' do      
+      visit dashboard_order_path(@order_1)
+      expect(page).to have_content("Coupon applied: #{@coupon.code}")
+      expect(page).to have_content("Discount: #{@coupon.amount}% on your items")
+      
+      visit dashboard_order_path(@order_2)
+      expect(page).to have_content("Coupon applied: #{@coupon_2.code}")
+      expect(page).to have_content("Discount: #{number_to_currency(@coupon_2.amount)}, cart minimum #{number_to_currency(@coupon_2.cart_minimum)}")
     end
   end
 

--- a/spec/features/merchant/dashboard_spec.rb
+++ b/spec/features/merchant/dashboard_spec.rb
@@ -276,10 +276,11 @@ RSpec.describe 'Merchant Dashboard page' do
   end
   
   context 'To Do List' do
+    before(:each) do
+      @merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
     it 'should show me a to do list' do
-      merchant = create(:merchant)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-      
       visit dashboard_path
       
       expect(page).to have_content("To Do List")
@@ -289,13 +290,10 @@ RSpec.describe 'Merchant Dashboard page' do
       end
     end
     
-    it 'should show me all items that are using placeholder images' do
-      merchant = create(:merchant)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-      
-      item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-      item_2 = create(:item, user: merchant)
-      item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+    it 'should show me all items that are using placeholder images' do      
+      item_1 = create(:item, user: @merchant, image: 'https://picsum.photos/200/300/?image=524')
+      item_2 = create(:item, user: @merchant)
+      item_3 = create(:item, user: @merchant, image: 'https://picsum.photos/200/300/?image=524')
       
       visit dashboard_path
       
@@ -307,12 +305,9 @@ RSpec.describe 'Merchant Dashboard page' do
     end
     
     it 'should let me update items with placeholder images' do
-      merchant = create(:merchant)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-      
-      item_1 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
-      item_2 = create(:item, user: merchant)
-      item_3 = create(:item, user: merchant, image: 'https://picsum.photos/200/300/?image=524')
+      item_1 = create(:item, user: @merchant, image: 'https://picsum.photos/200/300/?image=524')
+      item_2 = create(:item, user: @merchant)
+      item_3 = create(:item, user: @merchant, image: 'https://picsum.photos/200/300/?image=524')
       
       visit dashboard_path
       
@@ -334,12 +329,9 @@ RSpec.describe 'Merchant Dashboard page' do
     end
     
     it 'should show me information about my unfulfilled orders' do
-      merchant = create(:merchant)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
-      
-      item_1 = create(:item, user: merchant)
-      item_2 = create(:item, user: merchant)
-      item_3 = create(:item, user: merchant)
+      item_1 = create(:item, user: @merchant)
+      item_2 = create(:item, user: @merchant)
+      item_3 = create(:item, user: @merchant)
       
       order_1 = create(:order)
       order_2 = create(:order)
@@ -380,6 +372,36 @@ RSpec.describe 'Merchant Dashboard page' do
     end
   end
   
+  describe 'when I have pending orders with coupons applied' do
+    it 'should show me the coupon info' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      
+      coupon = create(:percent_coupon)
+      coupon_2 = create(:dollar_coupon, cart_minimum: 1)
+      
+      order_1 = create(:order)
+      order_2 = create(:order)
+      
+      oi_1 = create(:coupon_order_item, item: item_1, order: order_1, coupon: coupon)
+      oi_2 = create(:coupon_order_item, item: item_2, order: order_1, coupon: coupon_2)
+      
+      visit dashboard_path
+      
+      within "#order-#{order_1.id}" do
+        expect(page).to have_content("Coupon applied: #{coupon.code}")
+        expect(page).to have_content("Discount: #{coupon.amount}% on your items")
+      end
+      
+      within "#order-#{order_2.id}" do
+        expect(page).to have_content("Coupon applied: #{coupon_2.code}")
+        expect(page).to have_content("Discount: #{number_to_currency(coupon_2.amount)}, cart minimum #{number_to_currency(coupon_2.cart_minimum)}")
+      end
+    end
+  end
 
   context 'as an admin' do
   end

--- a/spec/features/merchant/dashboard_spec.rb
+++ b/spec/features/merchant/dashboard_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe 'Merchant Dashboard page' do
       order_2 = create(:order)
       
       oi_1 = create(:coupon_order_item, item: item_1, order: order_1, coupon: coupon)
-      oi_2 = create(:coupon_order_item, item: item_2, order: order_1, coupon: coupon_2)
+      oi_2 = create(:coupon_order_item, item: item_2, order: order_2, coupon: coupon_2)
       
       visit dashboard_path
       

--- a/spec/features/user/profile_orders_spec.rb
+++ b/spec/features/user/profile_orders_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe 'Profile Orders page', type: :feature do
       @oi_1 = create(:order_item, order: @order, item: @item_1, price: 1, quantity: 1, created_at: yesterday, updated_at: yesterday)
       @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, price: 2, quantity: 1, created_at: yesterday, updated_at: 2.hours.ago)
       
-      create(:coupon_order_item, order: @order, coupon: @coupon)
+      @oi_3 = create(:coupon_order_item, order: @order, coupon: @coupon)
     end
     scenario 'when logged in as user' do
       @user.reload
@@ -267,6 +267,16 @@ RSpec.describe 'Profile Orders page', type: :feature do
       expect(page).to have_content("#{number_to_currency(@coupon.cart_minimum)} cart minimum amount")
       expect(page).to have_content("Item Count: #{@order.total_item_count}")
       expect(page).to have_content("Total Cost: #{number_to_currency(@order.total_cost)}")
+
+      within "#oitem-#{@oi_3.id}" do
+        expect(page).to have_content("Discount: #{number_to_currency(@coupon.amount)}")
+      end
+      within "#oitem-#{@oi_1.id}" do
+        expect(page).to_not have_content("Discount")
+      end
+      within "#oitem-#{@oi_2.id}" do
+        expect(page).to_not have_content("Discount")
+      end
     end
   end
 end

--- a/spec/features/user/profile_orders_spec.rb
+++ b/spec/features/user/profile_orders_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe 'Profile Orders page', type: :feature do
     before :each do
       yesterday = 1.day.ago
       @order = create(:order, user: @user, created_at: yesterday)
-      @coupon = create(:dollar_coupon)
+      @coupon = create(:percent_coupon)
       @oi_1 = create(:order_item, order: @order, item: @item_1, price: 1, quantity: 1, created_at: yesterday, updated_at: yesterday)
       @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, price: 2, quantity: 1, created_at: yesterday, updated_at: 2.hours.ago)
       
@@ -263,13 +263,12 @@ RSpec.describe 'Profile Orders page', type: :feature do
     end
     after :each do
       expect(page).to have_content("Coupon applied: #{@coupon.code} for merchant: #{@coupon.user.name}")
-      expect(page).to have_content("Discount: #{number_to_currency(@coupon.amount)}")
-      expect(page).to have_content("#{number_to_currency(@coupon.cart_minimum)} cart minimum amount")
+      expect(page).to have_content("Discount: #{@coupon.amount}%")
       expect(page).to have_content("Item Count: #{@order.total_item_count}")
       expect(page).to have_content("Total Cost: #{number_to_currency(@order.total_cost)}")
 
       within "#oitem-#{@oi_3.id}" do
-        expect(page).to have_content("Discount: #{number_to_currency(@coupon.amount)}")
+        expect(page).to have_content("Discount: #{@coupon.amount}%")
       end
       within "#oitem-#{@oi_1.id}" do
         expect(page).to_not have_content("Discount")


### PR DESCRIPTION
- Add coupon info to a number of other pages:
  - dashboard orders
  - dashboard order show page
  - items on user order show page
- Applies basic styling to coupon section of pages
- Adds coupons index page link to merchant dashboard
- All test passing
Completes #30 